### PR TITLE
fix: [ws] sock shouldn't throw eof error when failed to read frame (#…

### DIFF
--- a/std/http/server_test.ts
+++ b/std/http/server_test.ts
@@ -12,7 +12,8 @@ import {
   assertEquals,
   assertNotEquals,
   assertThrowsAsync,
-  AssertionError
+  AssertionError,
+  assertNotEOF
 } from "../testing/asserts.ts";
 import {
   Response,
@@ -31,11 +32,6 @@ import {
 } from "../io/bufio.ts";
 import { delay, deferred } from "../util/async.ts";
 import { StringReader } from "../io/readers.ts";
-
-function assertNotEOF<T extends {}>(val: T | Deno.EOF): T {
-  assertNotEquals(val, Deno.EOF);
-  return val as T;
-}
 
 interface ResponseTest {
   response: Response;

--- a/std/io/bufio_test.ts
+++ b/std/io/bufio_test.ts
@@ -8,8 +8,8 @@ type Reader = Deno.Reader;
 import {
   assert,
   assertEquals,
-  assertNotEquals,
-  fail
+  fail,
+  assertNotEOF
 } from "../testing/asserts.ts";
 import {
   BufReader,
@@ -23,11 +23,6 @@ import * as iotest from "./iotest.ts";
 import { charCode, copyBytes, stringsReader } from "./util.ts";
 
 const encoder = new TextEncoder();
-
-function assertNotEOF<T extends {}>(val: T | Deno.EOF): T {
-  assertNotEquals(val, Deno.EOF);
-  return val as T;
-}
 
 async function readBytes(buf: BufReader): Promise<string> {
   const b = new Uint8Array(1000);

--- a/std/testing/asserts.ts
+++ b/std/testing/asserts.ts
@@ -378,3 +378,8 @@ export function unimplemented(msg?: string): never {
 export function unreachable(): never {
   throw new AssertionError("unreachable");
 }
+
+export function assertNotEOF<T extends {}>(val: T | Deno.EOF): T {
+  assertNotEquals(val, Deno.EOF);
+  return val as T;
+}

--- a/std/textproto/reader_test.ts
+++ b/std/textproto/reader_test.ts
@@ -9,15 +9,10 @@ import { stringsReader } from "../io/util.ts";
 import {
   assert,
   assertEquals,
-  assertNotEquals,
-  assertThrows
+  assertThrows,
+  assertNotEOF
 } from "../testing/asserts.ts";
 const { test } = Deno;
-
-function assertNotEOF<T extends {}>(val: T | Deno.EOF): T {
-  assertNotEquals(val, Deno.EOF);
-  return val as T;
-}
 
 function reader(s: string): TextProtoReader {
   return new TextProtoReader(new BufReader(stringsReader(s)));

--- a/std/ws/test.ts
+++ b/std/ws/test.ts
@@ -13,13 +13,14 @@ import {
   readFrame,
   unmask,
   writeFrame,
-  createWebSocket
+  createWebSocket,
+  SocketClosedError
 } from "./mod.ts";
 import { encode, decode } from "../strings/mod.ts";
-type Writer = Deno.Writer;
-type Reader = Deno.Reader;
-type Conn = Deno.Conn;
-const { Buffer } = Deno;
+import Writer = Deno.Writer;
+import Reader = Deno.Reader;
+import Conn = Deno.Conn;
+import Buffer = Deno.Buffer;
 
 test(async function wsReadUnmaskedTextFrame(): Promise<void> {
   // unmasked single text frame with payload "Hello"
@@ -325,4 +326,61 @@ test("WebSocket.send(), WebSocket.ping() should be exclusive", async (): Promise
   assertEquals(ping.opcode, OpCode.Ping);
   assertEquals(third.opcode, OpCode.BinaryFrame);
   assertEquals(bytes.equal(third.payload, new Uint8Array([3])), true);
+});
+
+test("WebSocket should throw SocketClosedError when peer closed connection without close frame", async () => {
+  const buf = new Buffer();
+  const eofReader: Deno.Reader = {
+    async read(_: Uint8Array): Promise<number | Deno.EOF> {
+      return Deno.EOF;
+    }
+  };
+  const conn = dummyConn(eofReader, buf);
+  const sock = createWebSocket({ conn });
+  sock.closeForce();
+  await assertThrowsAsync(() => sock.send("hello"), SocketClosedError);
+  await assertThrowsAsync(() => sock.ping(), SocketClosedError);
+  await assertThrowsAsync(() => sock.close(0), SocketClosedError);
+});
+
+test("WebSocket shouldn't throw UnexpectedEOFError on recive()", async () => {
+  const buf = new Buffer();
+  const eofReader: Deno.Reader = {
+    async read(_: Uint8Array): Promise<number | Deno.EOF> {
+      return Deno.EOF;
+    }
+  };
+  const conn = dummyConn(eofReader, buf);
+  const sock = createWebSocket({ conn });
+  const it = sock.receive();
+  const { value, done } = await it.next();
+  assertEquals(value, undefined);
+  assertEquals(done, true);
+});
+
+test("WebSocket should reject sending promise when connection reset forcely", async () => {
+  const buf = new Buffer();
+  let timer: number | undefined;
+  const lazyWriter: Deno.Writer = {
+    async write(_: Uint8Array): Promise<number> {
+      return new Promise(resolve => {
+        timer = setTimeout(() => resolve(0), 1000);
+      });
+    }
+  };
+  const conn = dummyConn(buf, lazyWriter);
+  const sock = createWebSocket({ conn });
+  const onError = (e: unknown): unknown => e;
+  const p = Promise.all([
+    sock.send("hello").catch(onError),
+    sock.send(new Uint8Array([1, 2])).catch(onError),
+    sock.ping().catch(onError)
+  ]);
+  sock.closeForce();
+  assertEquals(sock.isClosed, true);
+  const [a, b, c] = await p;
+  assert(a instanceof SocketClosedError);
+  assert(b instanceof SocketClosedError);
+  assert(c instanceof SocketClosedError);
+  clearTimeout(timer);
 });


### PR DESCRIPTION
…4083)

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
