### PR TITLE
feat: Support types compiler option in compiler APIs (#4155)

### DIFF
--- a/cli/js/compiler_api.ts
+++ b/cli/js/compiler_api.ts
@@ -247,7 +247,21 @@ export interface CompilerOptions {
     | "es2020"
     | "esnext";
 
-  /** List of names of type definitions to include. Defaults to `undefined`. */
+  /** List of names of type definitions to include. Defaults to `undefined`.
+   *
+   * The type definitions are resolved according to the normal Deno resolution
+   * irrespective of if sources are provided on the call.  Like other Deno
+   * modules, there is no "magical" resolution.  For example:
+   *
+   *      Deno.compile(
+   *        "./foo.js",
+   *        undefined,
+   *        {
+   *          types: [ "./foo.d.ts", "https://deno.land/x/example/types.d.ts" ]
+   *        }
+   *      );
+   *
+   */
   types?: string[];
 }
 

--- a/cli/js/compiler_api_test.ts
+++ b/cli/js/compiler_api_test.ts
@@ -62,6 +62,21 @@ test(async function compilerApiCompileLib() {
   assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
 });
 
+test(async function compilerApiCompileTypes() {
+  const [diagnostics, actual] = await compile(
+    "/foo.ts",
+    {
+      "/foo.ts": `console.log(Foo.bar);`
+    },
+    {
+      types: ["./cli/tests/subdir/foo_types.d.ts"]
+    }
+  );
+  assert(diagnostics == null);
+  assert(actual);
+  assertEquals(Object.keys(actual), ["/foo.js.map", "/foo.js"]);
+});
+
 test(async function transpileOnlyApi() {
   const actual = await transpileOnly({
     "foo.ts": `export enum Foo { Foo, Bar, Baz };\n`

--- a/cli/js/compiler_util.ts
+++ b/cli/js/compiler_util.ts
@@ -182,12 +182,20 @@ export function createWriteFile(state: WriteFileState): WriteFileCallback {
   };
 }
 
+export interface ConvertCompilerOptionsResult {
+  files?: string[];
+  options: ts.CompilerOptions;
+}
+
 /** Take a runtime set of compiler options as stringified JSON and convert it
  * to a set of TypeScript compiler options. */
-export function convertCompilerOptions(str: string): ts.CompilerOptions {
+export function convertCompilerOptions(
+  str: string
+): ConvertCompilerOptionsResult {
   const options: CompilerOptions = JSON.parse(str);
   const out: Record<string, unknown> = {};
   const keys = Object.keys(options) as Array<keyof CompilerOptions>;
+  const files: string[] = [];
   for (const key of keys) {
     switch (key) {
       case "jsx":
@@ -261,11 +269,20 @@ export function convertCompilerOptions(str: string): ts.CompilerOptions {
           default:
             throw new TypeError("Unexpected emit target.");
         }
+        break;
+      case "types":
+        const types = options[key];
+        assert(types);
+        files.push(...types);
+        break;
       default:
         out[key] = options[key];
     }
   }
-  return out as ts.CompilerOptions;
+  return {
+    options: out as ts.CompilerOptions,
+    files: files.length ? files : undefined
+  };
 }
 
 /** An array of TypeScript diagnostic types we ignore. */

--- a/cli/js/lib.deno.ns.d.ts
+++ b/cli/js/lib.deno.ns.d.ts
@@ -2156,7 +2156,21 @@ declare namespace Deno {
       | "es2020"
       | "esnext";
 
-    /** List of names of type definitions to include. Defaults to `undefined`. */
+    /** List of names of type definitions to include. Defaults to `undefined`.
+     *
+     * The type definitions are resolved according to the normal Deno resolution
+     * irrespective of if sources are provided on the call.  Like other Deno
+     * modules, there is no "magical" resolution.  For example:
+     *
+     *      Deno.compile(
+     *        "./foo.js",
+     *        undefined,
+     *        {
+     *          types: [ "./foo.d.ts", "https://deno.land/x/example/types.d.ts" ]
+     *        }
+     *      );
+     *
+     */
     types?: string[];
   }
 

--- a/cli/tests/subdir/foo_types.d.ts
+++ b/cli/tests/subdir/foo_types.d.ts
@@ -1,0 +1,3 @@
+declare namespace Foo {
+  const bar: string;
+}


### PR DESCRIPTION
Handles `types` in the compiler APIs to make it easier to supply
external type libraries.

<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
