### PR TITLE
Fix `deno install` file name including extra dot on Windows (#4243)

### DIFF
--- a/cli/installer.rs
+++ b/cli/installer.rs
@@ -143,7 +143,7 @@ pub fn install(
   let mut file_path = installation_dir.join(exec_name);
 
   if cfg!(windows) {
-    file_path = file_path.with_extension(".cmd");
+    file_path = file_path.with_extension("cmd");
   }
 
   if file_path.exists() && !force {
@@ -229,7 +229,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join(".deno/bin/echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -263,7 +263,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -292,7 +292,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -319,7 +319,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
 
     assert!(file_path.exists());
@@ -343,7 +343,7 @@ mod tests {
 
     let mut file_path = temp_dir.path().join("echo_test");
     if cfg!(windows) {
-      file_path = file_path.with_extension(".cmd");
+      file_path = file_path.with_extension("cmd");
     }
     assert!(file_path.exists());
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -189,7 +189,7 @@ fn installer_test_local_module_run() {
   .expect("Failed to install");
   let mut file_path = temp_dir.path().join("echo_test");
   if cfg!(windows) {
-    file_path = file_path.with_extension(".cmd");
+    file_path = file_path.with_extension("cmd");
   }
   assert!(file_path.exists());
   let path_var_name = if cfg!(windows) { "Path" } else { "PATH" };
@@ -237,7 +237,7 @@ fn installer_test_remote_module_run() {
   .expect("Failed to install");
   let mut file_path = temp_dir.path().join("echo_test");
   if cfg!(windows) {
-    file_path = file_path.with_extension(".cmd");
+    file_path = file_path.with_extension("cmd");
   }
   assert!(file_path.exists());
   let path_var_name = if cfg!(windows) { "Path" } else { "PATH" };


### PR DESCRIPTION
<!--
Before submitting a PR, please read https://deno.land/std/manual.md#contributing
-->
